### PR TITLE
Bug Fix: Resolved Missing Key "organization" in Object

### DIFF
--- a/assets/bigcode.yaml
+++ b/assets/bigcode.yaml
@@ -17,7 +17,7 @@
   size: 15.5 Billion parameters
   analysis: unknown
   # Construction
-  dependencies: https://huggingface.co/datasets/bigcode/the-stack-dedup
+  dependencies: [https://huggingface.co/datasets/bigcode/the-stack-dedup]
   training_emissions: unknown
   training_time: 24 days
   training_hardware: GPUs-512 Tesla A100

--- a/assets/databricks.yaml
+++ b/assets/databricks.yaml
@@ -69,7 +69,7 @@
 
 - type: model
   name: dolly-v2-12b
-  organisation: databricks
+  organization: databricks
   description: Databricks' dolly-v2-12b, an instruction-following large language model
     trained on the Databricks machine learning platform that is licensed for commercial
     use.

--- a/assets/databricks.yaml
+++ b/assets/databricks.yaml
@@ -75,7 +75,7 @@
     use.
   created_date:
     value: Unknown
-    description: NA
+    explanation: NA
   url: NA
   model_card: https://huggingface.co/databricks/dolly-v2-12b#dolly-v2-12b-model-card
   modality: Text (English)

--- a/assets/declare-lab.yaml
+++ b/assets/declare-lab.yaml
@@ -1,6 +1,6 @@
 - type: model
   name: declare-lab/flan-alpaca-xl
-  organisation: declare-lab
+  organization: declare-lab
   description: ' Flan-Alpaca: Instruction Tuning from Humans and Machines'
   created_date:
     value: Unknown

--- a/assets/declare-lab.yaml
+++ b/assets/declare-lab.yaml
@@ -10,7 +10,7 @@
   modality: Text (English)
   size: 9.45 GB
   analysis: ''
-  dependencies: ''
+  dependencies: []
   training_emissions: ''
   training_time: ''
   training_hardware: ''

--- a/assets/infosys.yaml
+++ b/assets/infosys.yaml
@@ -10,7 +10,7 @@
   modality: Text (English)
   size: 9 GB
   analysis: ''
-  dependencies: ''
+  dependencies: []
   training_emissions: ''
   training_time: 12 hours
   training_hardware: 16GB Memory
@@ -40,7 +40,7 @@
   modality: Text (English)
   size: 9 GB
   analysis: ''
-  dependencies: ''
+  dependencies: []
   training_emissions: ''
   training_time: 18 hours
   training_hardware: 16GB Memory
@@ -70,7 +70,7 @@
   modality: Text (English)
   size: 9 GB
   analysis: ''
-  dependencies: ''
+  dependencies: []
   training_emissions: ''
   training_time: 20 hours
   training_hardware: 16GB Memory
@@ -99,7 +99,7 @@
   modality: Text (German)
   size: 12.9 GB
   analysis: ''
-  dependencies: ''
+  dependencies: []
   training_emissions: ''
   training_time: 26 hours
   training_hardware: 16GB Memory
@@ -129,7 +129,7 @@
   modality: Text (German)
   size: 12.9 GB
   analysis: ''
-  dependencies: ''
+  dependencies: []
   training_emissions: ''
   training_time: 30 hours
   training_hardware: 16GB Memory
@@ -160,7 +160,7 @@
   modality: Text (German)
   size: 5 GB
   analysis: ''
-  dependencies: ''
+  dependencies: []
   training_emissions: ''
   training_time: 20 hours
   training_hardware: 16GB Memory

--- a/assets/infosys.yaml
+++ b/assets/infosys.yaml
@@ -1,6 +1,6 @@
 - type: model
   name: infy-llama-alpaca-ams-data
-  organisation: Infosys
+  organization: Infosys
   description: Finetuned LLama on AMS dataset
   created_date:
     value: March 2023
@@ -30,7 +30,7 @@
 
 - type: model
   name: infy-llama-alpaca-sop-data
-  organisation: Infosys
+  organization: Infosys
   description: Finetuned LLama on SOP internal dataset
   created_date:
     value: April 2023
@@ -60,7 +60,7 @@
 
 - type: model
   name: infy-llama-alpaca-closed-domain-policy-qa
-  organisation: Infosys
+  organization: Infosys
   description: Finetuned LLama on policy instruction dataset internal
   created_date:
     value: April 2023
@@ -89,7 +89,7 @@
 
 - type: model
   name: infy-bloom-6b-german-dolly15k
-  organisation: Infosys
+  organization: Infosys
   description: Finetuned bloom on german instruction dataset
   created_date:
     value: April 2023
@@ -119,7 +119,7 @@
 
 - type: model
   name: infy-bloom-6b-german-dolly15k-shargpt12k
-  organisation: Infosys
+  organization: Infosys
   description: Finetuned bloom on german 27K instruction dataset
   created_date:
     value: April 2023
@@ -150,7 +150,7 @@
 
 - type: model
   name: infy-byt5-german-dolly15k-sharegpt12k
-  organisation: Infosys
+  organization: Infosys
   description: Finetuned byt5 model on german 27K instruction dataset
   created_date:
     value: April 2023

--- a/assets/lmsys.yaml
+++ b/assets/lmsys.yaml
@@ -1,6 +1,6 @@
 - type: model
   name: lmsys/fastchat-t5-3b-v1.0
-  organisation: lmsys
+  organization: lmsys
   description: FastChat-T5 is an open-source chatbot trained by fine-tuning Flan-t5-xl
     (3B parameters) on user-shared conversations collected from ShareGPT. It is based
     on an encoder-decoder transformer architecture, and can autoregressively generate

--- a/assets/lmsys.yaml
+++ b/assets/lmsys.yaml
@@ -13,7 +13,7 @@
   modality: Text (English)
   size: 6.7 GB
   analysis: ''
-  dependencies: ''
+  dependencies: []
   training_emissions: ''
   training_time: ''
   training_hardware: ''

--- a/assets/nvidia.yaml
+++ b/assets/nvidia.yaml
@@ -111,7 +111,7 @@
   modality: Text (English)
   size: 177.73 MB
   analysis: ''
-  dependencies: ''
+  dependencies: []
   training_emissions: ''
   training_time: NA
   training_hardware: NA
@@ -141,7 +141,7 @@
   modality: Text (English)
   size: 300 MB
   analysis: ''
-  dependencies: ''
+  dependencies: []
   training_emissions: ''
   training_time: NA
   training_hardware: NA
@@ -172,7 +172,7 @@
   modality: NA
   size: 1002.75 MB
   analysis: ''
-  dependencies: ''
+  dependencies: []
   training_emissions: ''
   training_time: ''
   training_hardware: ''
@@ -205,7 +205,7 @@
   modality: NA
   size: 329.96 MB
   analysis: ''
-  dependencies: ''
+  dependencies: []
   training_emissions: ''
   training_time: ''
   training_hardware: ''

--- a/assets/nvidia.yaml
+++ b/assets/nvidia.yaml
@@ -101,7 +101,7 @@
 
 - type: model
   name: Fastpitch
-  organisation: nvidia
+  organization: nvidia
   description: This model converts text to spectrogram.
   created_date:
     value: NA
@@ -131,7 +131,7 @@
 
 - type: model
   name: HIFIGAN
-  organisation: nvidia
+  organization: nvidia
   description: This model converts spectrogram to speech.
   created_date:
     value: NA
@@ -161,7 +161,7 @@
 
 - type: model
   name: NMT Multilingual De/Es/Fr En Transformer12x2
-  organisation: NVIDIA
+  organization: NVIDIA
   description: ' This model can be used for translating text in source language (De/Es/Fr)
     to a text in target language (En).'
   created_date:
@@ -193,7 +193,7 @@
 
 - type: model
   name: RIVA Conformer ASR English en-US
-  organisation: NVIDIA
+  organization: NVIDIA
   description: ' Conformer-CTC (around 120M parameters) is trained on ASRSet with
     over 16500 hours of English(en-US) speech. The model transcribes speech in lower
     case english alphabet along with spaces and apostrophes'

--- a/assets/openassistant.yaml
+++ b/assets/openassistant.yaml
@@ -13,7 +13,7 @@
   modality: Text (English)
   size: NA
   analysis: ''
-  dependencies: ''
+  dependencies: []
   training_emissions: ''
   training_time: ''
   training_hardware: ''

--- a/assets/openassistant.yaml
+++ b/assets/openassistant.yaml
@@ -1,6 +1,6 @@
 - type: model
   name: OpenAssistant/oasst-sft-4-pythia-12b-epoch-3.5
-  organisation: OpenAssistant
+  organization: OpenAssistant
   description: This is the 4th iteration English supervised-fine-tuning (SFT) model
     of the Open-Assistant project. It is based on a Pythia 12B that was fine-tuned
     on human demonstrations of assistant conversations collected through the https://open-assistant.io/

--- a/assets/salesforce.yaml
+++ b/assets/salesforce.yaml
@@ -124,7 +124,7 @@
   size: 1Billion, 3.7Billion, 7Billion, 16Billion parameters
   analysis: unknown 
   # Construction
-  dependencies: https://huggingface.co/datasets/bigcode/the-stack-dedup
+  dependencies: [https://huggingface.co/datasets/bigcode/the-stack-dedup]
   training_emissions: unknown 
   training_time: unknown
   training_hardware: unknown

--- a/assets/salesforce.yaml
+++ b/assets/salesforce.yaml
@@ -117,7 +117,7 @@
     value: 2023-06-03
     explanation: >
       This model can be easily loaded using the AutoModelForCausalLM functionality.
-  urls: https://arxiv.org/pdf/2305.02309.pdf
+  url: https://arxiv.org/pdf/2305.02309.pdf
 
   model_card: https://huggingface.co/Salesforce/codegen2-1B, https://huggingface.co/Salesforce/codegen2-3_7B, https://huggingface.co/Salesforce/codegen2-7B, https://huggingface.co/Salesforce/codegen2-16B
   modality: Text (English) and code

--- a/assets/tii.yaml
+++ b/assets/tii.yaml
@@ -12,7 +12,7 @@
   modality: Text (English)
   size: NA
   analysis: ''
-  dependencies: ''
+  dependencies: []
   training_emissions: ''
   training_time: ''
   training_hardware: ''

--- a/assets/tii.yaml
+++ b/assets/tii.yaml
@@ -1,6 +1,6 @@
 - type: model
   name: falcon-40b
-  organisation: Technology Innovation Institute
+  organization: Technology Innovation Institute
   description: Falcon-40B is a 40B parameters causal decoder-only model built by TII
     and trained on 1,000B tokens of RefinedWeb enhanced with curated corpora. It is
     made available under the Apache 2.0 license.


### PR DESCRIPTION
This pull request addresses an issue related to a missing key in an object, specifically the incorrect usage of "organisation" instead of "organization" as per the schema definition.

The bug was identified when attempting to load the ecosystem graph page. The existing code relied on the key "organisation" to retrieve the organization information, but according to the defined schema, the correct key should be "organization". This inconsistency resulted in errors and prevented application to load.